### PR TITLE
[codex] Fix scrollable preview and section tabs

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -73,7 +73,7 @@ const AppContent = observer(() => {
       <div className="flex h-screen flex-col bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-50">
         <TopBar />
 
-        <div className="relative flex flex-1 overflow-hidden">
+        <div className="relative flex min-h-0 flex-1 overflow-hidden">
           <aside
             className="min-w-[18rem] overflow-hidden border-r border-slate-200 bg-white shadow-inner dark:border-slate-700 dark:bg-slate-900"
             style={{ width: `${editorWidth}%` }}
@@ -87,7 +87,7 @@ const AppContent = observer(() => {
             aria-hidden="true"
           />
 
-          <main className="min-w-0 flex-1 overflow-hidden">
+          <main className="min-h-0 min-w-0 flex-1 overflow-hidden">
             <JakesHTMLPreview />
           </main>
 

--- a/apps/frontend/src/features/resume-editor/components/SectionTabs.tsx
+++ b/apps/frontend/src/features/resume-editor/components/SectionTabs.tsx
@@ -7,7 +7,7 @@ export function SectionTabs() {
   const [activeTab, setActiveTab] = useState<SectionTabKey>('personal');
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       <SectionTabNavigation activeTab={activeTab} onTabChange={setActiveTab} />
       <SectionTabContent activeTab={activeTab} />
     </div>

--- a/apps/frontend/src/features/resume-editor/components/section-tabs/SectionTabNavigation.tsx
+++ b/apps/frontend/src/features/resume-editor/components/section-tabs/SectionTabNavigation.tsx
@@ -10,12 +10,12 @@ export function SectionTabNavigation({
   onTabChange,
 }: SectionTabNavigationProps) {
   return (
-    <div className="flex gap-2 border-b bg-gray-50 px-4 py-2 dark:border-slate-600 dark:bg-slate-800">
+    <div className="flex max-w-full shrink-0 gap-2 overflow-x-auto overflow-y-hidden border-b bg-gray-50 px-4 py-2 dark:border-slate-600 dark:bg-slate-800">
       {SECTION_TABS.map(tab => (
         <button
           key={tab.key}
           onClick={() => onTabChange(tab.key)}
-          className={`rounded-t px-4 py-2 font-medium transition-colors ${
+          className={`shrink-0 rounded-t px-4 py-2 font-medium transition-colors ${
             activeTab === tab.key
               ? 'bg-white text-blue-600 dark:bg-slate-700 dark:text-blue-400'
               : 'text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300'

--- a/apps/frontend/src/features/templates/jakes/JakesHTMLPreview.tsx
+++ b/apps/frontend/src/features/templates/jakes/JakesHTMLPreview.tsx
@@ -44,9 +44,9 @@ export const JakesHTMLPreview = observer(() => {
   const inlineGap = spacing('personal', 'inlineGap');
 
   return (
-    <div className="flex justify-center overflow-auto bg-slate-100 p-6 dark:bg-slate-950">
+    <div className="h-full min-h-0 overflow-auto bg-slate-100 p-4 dark:bg-slate-950 sm:p-6">
       <div
-        className="min-h-[11in] w-[8.5in] bg-white px-8 py-7 text-slate-900 shadow-2xl dark:bg-slate-50"
+        className="mx-auto min-h-[11in] w-[8.5in] max-w-none bg-white px-8 py-7 text-slate-900 shadow-2xl dark:bg-slate-50"
         style={{
           paddingTop: toLatexUnit(pageMargins.top),
           paddingRight: toLatexUnit(pageMargins.right),


### PR DESCRIPTION
## Summary

Fixes the responsive scrolling issues reported in #6.

- constrains the main app and preview layout so the preview owns a scrollable viewport on short screens
- keeps the resume page centered while preserving horizontal scrolling for the fixed-width preview
- allows the section tab navigation to scroll horizontally instead of clipping tabs on narrow sidebars

## Root Cause

The preview component had `overflow-auto`, but its parent flex layout did not pass a constrained height down to it. The section tab row also used a fixed flex row without overflow handling, so tabs were clipped when the sidebar became narrow.

## Validation

- `corepack pnpm --filter @resume-builder/frontend exec tsc --noEmit`
- `corepack pnpm --filter @resume-builder/frontend build`

Closes #6