### PR TITLE
[codex] Fix resizable editor divider

### DIFF
--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -1,12 +1,16 @@
-name: Frontend Deploy
+name: Branch CI
 
 on:
   push:
+    branches-ignore:
+      - main
+  pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -1,9 +1,6 @@
 name: Branch CI
 
 on:
-  push:
-    branches-ignore:
-      - main
   pull_request:
     branches:
       - main

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
-import { TopBar } from './features/app-shell';
+import { ResizableDivider, TopBar, useResizablePanel } from './features/app-shell';
 import { SectionTabs } from './features/resume-editor';
 import { DashboardPanel } from './features/resume-management';
 import { FormattingPanel } from './features/formatting';
@@ -8,15 +8,16 @@ import { JakesHTMLPreview } from './features/templates';
 import { useStores, StoreProvider } from './features/shared/state';
 import { usePersistence } from './features/shared/hooks/usePersistence';
 
-const MIN_EDITOR_WIDTH = 28;
-const MAX_EDITOR_WIDTH = 56;
-
-const clamp = (value: number, min: number, max: number): number =>
-  Math.min(max, Math.max(min, value));
+const EDITOR_RESIZE_CONFIG = {
+  defaultValue: 40,
+  min: 28,
+  max: 56,
+  label: 'Resize editor and preview panels',
+};
 
 const AppContent = observer(() => {
   const { appStore } = useStores();
-  const [editorWidth, setEditorWidth] = useState(40);
+  const editorResize = useResizablePanel(EDITOR_RESIZE_CONFIG);
 
   useEffect(() => {
     if (appStore.resumes.length === 0) {
@@ -29,36 +30,6 @@ const AppContent = observer(() => {
   }, [appStore.colorTheme]);
 
   usePersistence(appStore);
-
-  useEffect(() => {
-    const handleMouseMove = (event: MouseEvent): void => {
-      const nextWidth = (event.clientX / window.innerWidth) * 100;
-      setEditorWidth(clamp(nextWidth, MIN_EDITOR_WIDTH, MAX_EDITOR_WIDTH));
-    };
-
-    const handleMouseUp = (): void => {
-      window.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('mouseup', handleMouseUp);
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-    };
-
-    const handleMouseDown = (event: MouseEvent): void => {
-      event.preventDefault();
-      document.body.style.cursor = 'col-resize';
-      document.body.style.userSelect = 'none';
-      window.addEventListener('mousemove', handleMouseMove);
-      window.addEventListener('mouseup', handleMouseUp);
-    };
-
-    const handle = document.getElementById('editor-resize-handle');
-    handle?.addEventListener('mousedown', handleMouseDown);
-
-    return () => {
-      handle?.removeEventListener('mousedown', handleMouseDown);
-      handleMouseUp();
-    };
-  }, []);
 
   if (!appStore.activeResume) {
     return (
@@ -73,18 +44,22 @@ const AppContent = observer(() => {
       <div className="flex h-screen flex-col bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-50">
         <TopBar />
 
-        <div className="relative flex min-h-0 flex-1 overflow-hidden">
+        <div ref={editorResize.containerRef} className="relative flex min-h-0 flex-1 overflow-hidden">
           <aside
             className="min-w-[18rem] overflow-hidden border-r border-slate-200 bg-white shadow-inner dark:border-slate-700 dark:bg-slate-900"
-            style={{ width: `${editorWidth}%` }}
+            style={{ width: `${editorResize.value}%` }}
           >
             <SectionTabs />
           </aside>
 
-          <div
-            id="editor-resize-handle"
-            className="w-1 cursor-col-resize bg-slate-200 transition hover:bg-indigo-400 dark:bg-slate-700 dark:hover:bg-indigo-500"
-            aria-hidden="true"
+          <ResizableDivider
+            label={EDITOR_RESIZE_CONFIG.label}
+            min={editorResize.min}
+            max={editorResize.max}
+            value={editorResize.value}
+            isResizing={editorResize.isResizing}
+            onPointerDown={editorResize.handlePointerDown}
+            onKeyDown={editorResize.handleKeyDown}
           />
 
           <main className="min-h-0 min-w-0 flex-1 overflow-hidden">

--- a/apps/frontend/src/features/app-shell/components/ResizableDivider.tsx
+++ b/apps/frontend/src/features/app-shell/components/ResizableDivider.tsx
@@ -1,0 +1,41 @@
+import type {
+  KeyboardEventHandler,
+  PointerEventHandler,
+} from 'react';
+
+interface ResizableDividerProps {
+  label: string;
+  min: number;
+  max: number;
+  value: number;
+  isResizing: boolean;
+  onPointerDown: PointerEventHandler<HTMLDivElement>;
+  onKeyDown: KeyboardEventHandler<HTMLDivElement>;
+}
+
+export const ResizableDivider = ({
+  label,
+  min,
+  max,
+  value,
+  isResizing,
+  onPointerDown,
+  onKeyDown,
+}: ResizableDividerProps) => (
+  <div
+    className={`w-1 cursor-col-resize bg-slate-200 transition hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-500 dark:bg-slate-700 dark:hover:bg-indigo-500 ${
+      isResizing ? 'bg-indigo-400 dark:bg-indigo-500' : ''
+    }`}
+    role="separator"
+    aria-label={label}
+    aria-orientation="vertical"
+    aria-valuemin={min}
+    aria-valuemax={max}
+    aria-valuenow={Math.round(value)}
+    tabIndex={0}
+    onPointerDown={onPointerDown}
+    onKeyDown={onKeyDown}
+  />
+);
+
+ResizableDivider.displayName = 'ResizableDivider';

--- a/apps/frontend/src/features/app-shell/hooks/useResizablePanel.ts
+++ b/apps/frontend/src/features/app-shell/hooks/useResizablePanel.ts
@@ -1,0 +1,111 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
+
+export interface ResizablePanelConfig {
+  defaultValue: number;
+  min: number;
+  max: number;
+  step?: number;
+  largeStep?: number;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+export const useResizablePanel = ({
+  defaultValue,
+  min,
+  max,
+  step = 2,
+  largeStep = 5,
+}: ResizablePanelConfig) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [value, setValue] = useState(defaultValue);
+  const [isResizing, setIsResizing] = useState(false);
+
+  const updateValue = useCallback(
+    (clientX: number): void => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      const { left, width } = container.getBoundingClientRect();
+      if (width === 0) return;
+
+      const nextValue = ((clientX - left) / width) * 100;
+      setValue(clamp(nextValue, min, max));
+    },
+    [max, min]
+  );
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const handlePointerMove = (event: PointerEvent): void => {
+      updateValue(event.clientX);
+    };
+
+    const stopResizing = (): void => {
+      setIsResizing(false);
+    };
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', stopResizing);
+    window.addEventListener('pointercancel', stopResizing);
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', stopResizing);
+      window.removeEventListener('pointercancel', stopResizing);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+  }, [isResizing, updateValue]);
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>): void => {
+    event.preventDefault();
+    updateValue(event.clientX);
+    setIsResizing(true);
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+    const resizeStep = event.shiftKey ? largeStep : step;
+
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      setValue(currentValue => clamp(currentValue - resizeStep, min, max));
+    }
+
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      setValue(currentValue => clamp(currentValue + resizeStep, min, max));
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault();
+      setValue(min);
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault();
+      setValue(max);
+    }
+  };
+
+  return {
+    containerRef,
+    value,
+    isResizing,
+    min,
+    max,
+    handlePointerDown,
+    handleKeyDown,
+  };
+};

--- a/apps/frontend/src/features/app-shell/index.ts
+++ b/apps/frontend/src/features/app-shell/index.ts
@@ -1,1 +1,3 @@
+export { ResizableDivider } from './components/ResizableDivider';
 export { TopBar } from './components/TopBar';
+export { useResizablePanel } from './hooks/useResizablePanel';


### PR DESCRIPTION
## Summary

Fixes #7.

- Restores the editor/preview divider resize behavior using pointer events instead of a one-time DOM lookup.
- Moves the resize mechanics into `useResizablePanel` and `ResizableDivider` so `App.tsx` only configures and wires the layout.
- Includes the current workflow changes from the working tree, including branch CI and frontend workflow updates.

## Root Cause

The previous implementation queried the divider element once in an effect. On the initial render, the active resume had not been created yet, so the divider was not mounted and the resize listener was never attached.

## Validation

- `pnpm type-check`
- `pnpm lint`
- `pnpm build`